### PR TITLE
Improve command bus with Command and AggregateId interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,12 @@
 <summary>Unreleased</summary>
 
 ### BREAKING CHANGES
+- `\BSP\CommandBus\Contracts\CommandBus::execute` now takes a `\BSP\CommandBus\Contracts\Command` as parameter instead of `object`
+- `\BSP\CommandBus\SimpleCommandBus::execute` now takes a `\BSP\CommandBus\Contracts\Command` as parameter instead of `object`
 
 ### New features
+- added `\BSP\CommandBus\Contracts\AggregateId`
+- added `\BSP\CommandBus\Contracts\Command`
 
 ### Bugfixes
 

--- a/src/Contracts/AggregateId.php
+++ b/src/Contracts/AggregateId.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types=1);
+
+namespace BSP\CommandBus\Contracts;
+
+interface AggregateId
+{
+    public function __toString();
+}

--- a/src/Contracts/Command.php
+++ b/src/Contracts/Command.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace BSP\CommandBus\Contracts;
+
+/**
+ * A Command will be applied on an Aggregate and must provide its id.
+ */
+interface Command
+{
+    public function aggregateId(): AggregateId;
+}

--- a/src/Contracts/CommandBus.php
+++ b/src/Contracts/CommandBus.php
@@ -16,5 +16,5 @@ interface CommandBus
      * @throws CommandHandlerNotFound
      * @throws CommandHandlerIsNotCallable
      */
-    public function execute(object $command): void;
+    public function execute(Command $command): void;
 }

--- a/src/SimpleCommandBus.php
+++ b/src/SimpleCommandBus.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace BSP\CommandBus;
 
+use BSP\CommandBus\Contracts\Command;
 use BSP\CommandBus\Contracts\CommandBus;
 use BSP\CommandBus\Contracts\CommandHandlerMap;
 use BSP\CommandBus\Exception\CommandHandlerIsNotCallable;
@@ -17,7 +18,7 @@ final class SimpleCommandBus implements CommandBus
         $this->handlers = $commandHandlerMap->map();
     }
 
-    public function execute(object $command): void
+    public function execute(Command $command): void
     {
         $commandClass = \get_class($command);
 

--- a/tests/Stub/AddSugarToCoffee.php
+++ b/tests/Stub/AddSugarToCoffee.php
@@ -3,7 +3,10 @@ declare(strict_types=1);
 
 namespace BSP\CommandBus\Tests\Stub;
 
-final class AddSugarToCoffee
+use BSP\CommandBus\Contracts\AggregateId;
+use BSP\CommandBus\Contracts\Command;
+
+final class AddSugarToCoffee implements Command
 {
     private $nbSugars;
     private $coffee;
@@ -22,5 +25,10 @@ final class AddSugarToCoffee
     public function coffee(): Coffee
     {
         return $this->coffee;
+    }
+
+    public function aggregateId(): AggregateId
+    {
+        return $this->coffee->coffeeId;
     }
 }

--- a/tests/Stub/BuyCoffee.php
+++ b/tests/Stub/BuyCoffee.php
@@ -2,6 +2,13 @@
 
 namespace BSP\CommandBus\Tests\Stub;
 
-final class BuyCoffee
+use BSP\CommandBus\Contracts\AggregateId;
+use BSP\CommandBus\Contracts\Command;
+
+final class BuyCoffee implements Command
 {
+    public function aggregateId(): AggregateId
+    {
+        return new CoffeeId();
+    }
 }

--- a/tests/Stub/Coffee.php
+++ b/tests/Stub/Coffee.php
@@ -5,5 +5,13 @@ namespace BSP\CommandBus\Tests\Stub;
 
 final class Coffee
 {
+    /** @var CoffeeId */
+    public $coffeeId;
+
     public static $sugars = 0;
+
+    public function __construct()
+    {
+        $this->coffeeId = new CoffeeId();
+    }
 }

--- a/tests/Stub/CoffeeId.php
+++ b/tests/Stub/CoffeeId.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1);
+
+namespace BSP\CommandBus\Tests\Stub;
+
+use BSP\CommandBus\Contracts\AggregateId;
+
+final class CoffeeId implements AggregateId
+{
+    public function __toString()
+    {
+        return '';
+    }
+}

--- a/tests/Stub/ServeCoffeeInCup.php
+++ b/tests/Stub/ServeCoffeeInCup.php
@@ -3,6 +3,13 @@ declare(strict_types=1);
 
 namespace BSP\CommandBus\Tests\Stub;
 
-final class ServeCoffeeInCup
+use BSP\CommandBus\Contracts\AggregateId;
+use BSP\CommandBus\Contracts\Command;
+
+final class ServeCoffeeInCup implements Command
 {
+    public function aggregateId(): AggregateId
+    {
+        return new CoffeeId();
+    }
 }


### PR DESCRIPTION
Command should always be applied on an Aggregate, thus, it should carry its target AggregateId